### PR TITLE
kubectl apply時にvalidation errになる問題を修正

### DIFF
--- a/deploy/kubernetes/manifests/carts-db-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/carts-dep.yaml
+++ b/deploy/kubernetes/manifests/carts-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: carts
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: carts
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/catalogue-db-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/catalogue-dep.yaml
+++ b/deploy/kubernetes/manifests/catalogue-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: catalogue
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: catalogue
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/front-end-dep.yaml
+++ b/deploy/kubernetes/manifests/front-end-dep.yaml
@@ -1,11 +1,14 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: front-end
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: front-end
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/orders-db-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/orders-dep.yaml
+++ b/deploy/kubernetes/manifests/orders-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: orders
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: orders
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/payment-dep.yaml
+++ b/deploy/kubernetes/manifests/payment-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: payment
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: payment
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/queue-master-dep.yaml
+++ b/deploy/kubernetes/manifests/queue-master-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: queue-master
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: queue-master
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/rabbitmq-dep.yaml
+++ b/deploy/kubernetes/manifests/rabbitmq-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rabbitmq
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: rabbitmq
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/session-db-dep.yaml
+++ b/deploy/kubernetes/manifests/session-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: session-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: session-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/shipping-dep.yaml
+++ b/deploy/kubernetes/manifests/shipping-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: shipping
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: shipping
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/user-db-dep.yaml
+++ b/deploy/kubernetes/manifests/user-db-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user-db
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user-db
   template:
     metadata:
       labels:

--- a/deploy/kubernetes/manifests/user-dep.yaml
+++ b/deploy/kubernetes/manifests/user-dep.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: user
@@ -8,6 +8,9 @@ metadata:
   namespace: sock-shop
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      name: user
   template:
     metadata:
       labels:


### PR DESCRIPTION
### 概要
k8s v.17相当のAPIにて動作するよう、manifest fileを修正

### テスト結果
以下のバージョンにて `kubectl apply` したpodがrunningに遷移することを確認

- client v1.18.2
- server v1.17.14-gke.400
